### PR TITLE
Add CycleError option to DFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Arguments:
 
  * *sourceNodes* (optional) - An array of node identifier strings. This specifies the subset of nodes to use as the sources of the depth-first search. If *sourceNodes* is not specified, all **[nodes](#nodes)** in the graph are used as source nodes.
  * *includeSourceNodes* (optional) - A boolean specifying whether or not to include the source nodes in the returned array. If *includeSourceNodes* is not specified, it is treated as `true` (all source nodes are included in the returned array).
- * *errorOnCycle* (optional) - A boolean indicating that a `CycleError` should be thrown whenever a cycle is first encountered.
+ * *errorOnCycle* (optional) - A boolean indicating that a `CycleError` should be thrown whenever a cycle is first encountered. Defaults to `false`.
 
 
 <a name="has-cycle" href="#has-cycle">#</a> <i>graph</i>.<b>hasCycle</b>()
@@ -242,4 +242,3 @@ Performs [Dijkstras Algorithm](https://en.wikipedia.org/wiki/Dijkstra%27s_algori
     <img src="https://cloud.githubusercontent.com/assets/68416/15298394/a7a0a66a-1bbc-11e6-9636-367bed9165fc.png">
   </a>
 </p>
-

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Deserializes the given serialized graph. Returns *graph* to support method chain
 
 ### Graph Algorithms
 
-<a name="dfs" href="#dfs">#</a> <i>graph</i>.<b>depthFirstSearch</b>([<i>sourceNodes</i>][, <i>includeSourceNodes</i>])
+<a name="dfs" href="#dfs">#</a> <i>graph</i>.<b>depthFirstSearch</b>([<i>sourceNodes</i>][, <i>includeSourceNodes</i>][, <i>errorOnCycle</i>])
 
 Performs [Depth-first Search](https://en.wikipedia.org/wiki/Depth-first_search). Returns an array of node identifier strings. The returned array includes nodes visited by the algorithm in the order in which they were visited. Implementation inspired by pseudocode from Cormen et al. "Introduction to Algorithms" 3rd Ed. p. 604.
 
@@ -209,6 +209,12 @@ Arguments:
 
  * *sourceNodes* (optional) - An array of node identifier strings. This specifies the subset of nodes to use as the sources of the depth-first search. If *sourceNodes* is not specified, all **[nodes](#nodes)** in the graph are used as source nodes.
  * *includeSourceNodes* (optional) - A boolean specifying whether or not to include the source nodes in the returned array. If *includeSourceNodes* is not specified, it is treated as `true` (all source nodes are included in the returned array).
+ * *errorOnCycle* (optional) - A boolean indicating that a `CycleError` should be thrown whenever a cycle is first encountered.
+
+
+<a name="has-cycle" href="#has-cycle">#</a> <i>graph</i>.<b>hasCycle</b>()
+
+Checks if the graph has any cycles. Returns `true` if it does and `false` otherwise.
 
 <a name="lca" href="#lca">#</a> <i>graph</i>.<b>lowestCommonAncestors</b>([<i>node1</i>][, <i>node2</i>])
 
@@ -224,6 +230,8 @@ Arguments:
 Performs [Topological Sort](https://en.wikipedia.org/wiki/Topological_sorting). Returns an array of node identifier strings. The returned array includes nodes in topologically sorted order. This means that for each visited edge (**u** -> **v**), **u** comes before **v** in the topologically sorted order. Amazingly, this comes from simply reversing the result from depth first search. Inspired by by Cormen et al. "Introduction to Algorithms" 3rd Ed. p. 613.
 
 See **[depthFirstSearch](#dfs)** for documentation of the arguments *sourceNodes* and *includeSourceNodes*.
+
+Note: this function raises a `CycleError` when the input is not a DAG.
 
 <a name="shortest-path" href="#shortest-path">#</a> <i>graph</i>.<b>shortestPath</b>(<i>sourceNode</i>, <i>destinationNode</i>)
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,8 @@ declare function Graph(serialized?: Serialized): {
     getEdgeWeight: (u: NodeId, v: NodeId) => EdgeWeight;
     indegree: (node: NodeId) => number;
     outdegree: (node: NodeId) => number;
-    depthFirstSearch: (sourceNodes?: string[] | undefined, includeSourceNodes?: boolean) => string[];
+    depthFirstSearch: (sourceNodes?: string[] | undefined, includeSourceNodes?: boolean, errorOnCycle?: boolean) => string[];
+    hasCycle: () => boolean;
     lowestCommonAncestors: (node1: NodeId, node2: NodeId) => string[];
     topologicalSort: (sourceNodes: NodeId[], includeSourceNodes?: boolean) => string[];
     shortestPath: (source: NodeId, destination: NodeId) => string[] & {

--- a/test.js
+++ b/test.js
@@ -148,6 +148,34 @@ describe("Graph", function() {
 
   describe("Algorithms", function() {
 
+    it("Should detect cycle.", function() {
+      var graph = Graph();
+      graph.addEdge("a", "b");
+      graph.addEdge("b", "a");
+      assert(graph.hasCycle());
+    });
+
+    it("Should detect cycle (long).", function() {
+      var graph = Graph();
+      graph.addEdge("a", "b");
+      graph.addEdge("b", "c");
+      graph.addEdge("c", "d");
+      graph.addEdge("d", "a");
+      assert(graph.hasCycle());
+    });
+
+    it("Should detect cycle (loop).", function() {
+      var graph = Graph();
+      graph.addEdge("a", "a");
+      assert(graph.hasCycle());
+    });
+
+    it("Should not detect cycle.", function() {
+      var graph = Graph();
+      graph.addEdge("a", "b");
+      assert(!graph.hasCycle());
+    });
+
     // This example is from Cormen et al. "Introduction to Algorithms" page 550
     it("Should compute topological sort.", function (){
 
@@ -244,6 +272,13 @@ describe("Graph", function() {
       assert(!contains(sorted, "b"));
 
       output(graph, "cycles");
+    });
+
+    it("Should error on non-DAG topological sort", function() {
+      var graph = Graph();
+      graph.addEdge("a", "b");
+      graph.addEdge("b", "a");
+      assert.throws(graph.topologicalSort);
     });
 
     it("Should compute lowest common ancestors.", function (){


### PR DESCRIPTION
- Adds optional `errorOnCycle` flag to DFS algorithm
- Sets `errorOnCycle` to `true` for topological sort
- Adds `hasCycle` function

Closes #41 and partially addresses #32. For the latter, a different algorithm other than DFS would be required to implement a function who returns that actual cycles themselves.  