### PR TITLE
Optimize hasEdge

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,15 +137,7 @@ function Graph(serialized) {
     }
     // Returns true if there is an edge from node u to node v.
     function hasEdge(u, v) {
-        var has = false;
-        if (edges[u]) {
-            adjacent(u).forEach(function (_v) {
-                if (_v === v) {
-                    has = true;
-                }
-            });
-        }
-        return has;
+        return adjacent(u).includes(v);
     }
     // Computes the indegree for the given node.
     // Not very efficient, costs O(E) where E = number of edges.

--- a/index.ts
+++ b/index.ts
@@ -146,15 +146,7 @@ function Graph(serialized?: Serialized) {
 
     // Returns true if there is an edge from node u to node v.
     function hasEdge(u: NodeId, v: NodeId) {
-        let has = false;
-        if (edges[u]) {
-            adjacent(u).forEach(function(_v) {
-                if(_v === v){
-                    has = true;
-                }
-            });
-        }
-        return has;
+        return adjacent(u).includes(v);
     }
 
     // Computes the indegree for the given node.


### PR DESCRIPTION
This should be a more efficient implementation, as it can be assumed that the implementation of `includes` returns early when the first match is found.

Uses: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes

The downside is that this is not compatible with Internet Explorer. But I think that's OK.