### PR TITLE
Fix missing types declaration in `exports` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "type": "module",
   "exports": {
     "require": "./dist/index.cjs",
-    "default": "./dist/index.modern.js"
+    "default": "./dist/index.modern.js",
+    "types": "./dist/index.d.ts"
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.module.js",


### PR DESCRIPTION
When compiling against this library in an ESM project, I get the error:

```
error TS7016: Could not find a declaration file for module 'graph-data-structure'.
```

Adding the `types` conditional export resolves the issue. I see there's the classic style top level `types` field, but the `exports` field takes precedence over that.