### PR TITLE
fix: wrong types reference in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "source": "src/index.ts",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
-  "types": "dist/index.d.ts",
+  "types": "dist/index.d.cts",
   "unpkg": "./dist/index.umd.js",
   "exports": {
     ".": {


### PR DESCRIPTION
 `dist/index.d.ts` doesn't exist, but `dist/index.d.cts` and `dist/index.d.mts` so i changed it to `dist/index.d.cts`.