### PR TITLE
Prevent data duplication with `serializeGraph` when using object nodes

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,15 +1,15 @@
 export type EdgeWeight = number;
 
-export type Edge<Node = unknown, Props = unknown> = {
-  source: Node;
-  target: Node;
+export type Edge<NodeIdentity = unknown, Props = unknown> = {
+  source: NodeIdentity;
+  target: NodeIdentity;
   weight?: EdgeWeight;
   props: Props;
 };
 
-export type Serialized<Node = unknown, LinkProps = unknown> = {
+export type Serialized<Node = unknown, LinkProps = unknown, NodeIdentity = Node> = {
   nodes: Node[];
-  links: Edge<Node, LinkProps>[];
+  links: Edge<NodeIdentity, LinkProps>[];
 };
 
 export type SerializedInput<Node = unknown, LinkProps = unknown> = {

--- a/src/utils/serializeGraph.spec.ts
+++ b/src/utils/serializeGraph.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expectTypeOf, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 import { Graph } from '../Graph.js';
 import { checkSerialized } from '../test-utils.js';
 import { Serialized } from '../types.js';
@@ -11,6 +11,44 @@ describe('serializeGraph', () => {
     const graph = new Graph<string>().addEdge('a', 'b').addEdge('b', 'c');
     serialized = serializeGraph(graph);
     checkSerialized(serialized);
+  });
+
+  it('should use the node identity for link serialization', function () {
+    const nodeA = { id: 1, title: 'a' };
+    const nodeB = { id: 2, title: 'b' };
+
+    const graph = new Graph<{ id: number; title: string }, { type: string }>();
+    graph.addEdge(nodeA, nodeB, { props: { type: 'foo' } });
+
+    const serialized = serializeGraph(graph, (n) => n.id);
+
+    expect(serialized).toStrictEqual({
+      nodes: [nodeA, nodeB],
+      links: [{ source: 1, target: 2, props: { type: 'foo' } }],
+    });
+  });
+
+  it('should reuse the same identity when the node is met multiple times', function () {
+    const nodeA = { id: 1, title: 'a' };
+    const nodeB = { id: 2, title: 'b' };
+    const nodeC = { id: 3, title: 'c' };
+
+    const graph = new Graph<{ id: number; title: string }>();
+    graph.addEdge(nodeA, nodeC);
+    graph.addEdge(nodeB, nodeC);
+
+    // we use an object as identity
+    const serialized = serializeGraph(graph, (n) => ({ id: n.id }));
+
+    const nodeIdentityC1 = serialized.links.find(
+      (l) => l.source.id === nodeA.id && l.target.id === nodeC.id,
+    )?.target;
+    const nodeIdentityC2 = serialized.links.find(
+      (l) => l.source.id === nodeB.id && l.target.id === nodeC.id,
+    )?.target;
+
+    expect(nodeIdentityC1).toBeDefined();
+    expect(nodeIdentityC1).toBe(nodeIdentityC2);
   });
 
   it.skip('should return a serialized input with type inferred from the graph', function () {


### PR DESCRIPTION
This PR adds a new optional argument to the `serializeGraph` function.
Similar to the identity function of `deserializeGraph`, the new argument is a function that returns a value that uniquely identify a node.

This value is then used when serializing links, leading to a more compact serialization. The serialization of nodes is not affected.

```ts
const nodeA = { id: 1, title: 'a' };
const nodeB = { id: 2, title: 'b' };

const graph = new Graph<{ id: number; title: string }>();
graph.addEdge(nodeA, nodeB);

const serialized = serializeGraph(graph);
// { links: [{ source: { id: 1, title: 'a' }, target: { id: 2, title: 'b' } }]}

const serializedWithIdentity = serializeGraph(graph, n => n.id);
// { links: [{ source: 1, target: 2 }]}
```