### PR TITLE
Fix build on Node.js v22

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,0 @@
-index.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,13 @@
       "devDependencies": {
         "@rollup/plugin-node-resolve": "15.3.0",
         "@rollup/plugin-terser": "0.4.4",
+        "@rollup/plugin-typescript": "12.1.1",
         "@types/node": "22.9.0",
         "microbundle": "0.15.1",
         "prettier": "3.3.3",
         "release-it": "17.10.0",
         "rollup": "4.26.0",
-        "rollup-plugin-ts": "3.4.5",
+        "rollup-plugin-dts": "6.1.1",
         "typescript": "5.6.3",
         "vitest": "2.1.5"
       }
@@ -2142,12 +2143,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@mdn/browser-compat-data": {
-      "version": "5.5.34",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.5.34.tgz",
-      "integrity": "sha512-e8k7+8r3jiJuP7FMH6AL1OnmfQqLyABhTM+NmRDvFeAbMgtFcNQLHpmT7uza5cBnxI01+CAU3aSsIgcKGRdEBQ==",
-      "dev": true
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2443,6 +2438,33 @@
       "dev": true,
       "dependencies": {
         "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/@rollup/plugin-typescript": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-12.1.1.tgz",
+      "integrity": "sha512-t7O653DpfB5MbFrqPe/VcKFFkvRuFNp9qId3xq4Eth5xlyymzxNpye2z8Hrl0RIMuXTSr5GGcFpkdlMeacUiFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.1.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.14.0||^3.0.0||^4.0.0",
+        "tslib": "*",
+        "typescript": ">=3.7.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        },
+        "tslib": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rollup/pluginutils": {
@@ -2773,12 +2795,6 @@
         "undici-types": "~6.19.8"
       }
     },
-    "node_modules/@types/object-path": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/@types/object-path/-/object-path-0.11.4.tgz",
-      "integrity": "sha512-4tgJ1Z3elF/tOMpA8JLVuR9spt9Ynsf7+JjqsQ2IqtiPJtcLoHoXcT6qU4E10cPFqyXX5HDm9QwIzZhBSkLxsw==",
-      "dev": true
-    },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
       "dev": true,
@@ -2792,18 +2808,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/semver": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
-      "dev": true
-    },
-    "node_modules/@types/ua-parser-js": {
-      "version": "0.7.39",
-      "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.39.tgz",
-      "integrity": "sha512-P/oDfpofrdtF5xw433SPALpdSchtJmY7nsJItf8h3KXqOslkbySh8zq4dSWXH2oTjRvJ5PczVEoCZPow6GicLg==",
-      "dev": true
     },
     "node_modules/@vitest/expect": {
       "version": "2.1.5",
@@ -2948,15 +2952,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@wessberg/stringutil": {
-      "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/@wessberg/stringutil/-/stringutil-1.0.19.tgz",
-      "integrity": "sha512-9AZHVXWlpN8Cn9k5BC/O0Dzb9E9xfEMXzYrNunwvkUTvuK7xgQPVRZpLo+jWCOZ5r8oBa8NIrHuPEu1hzbb6bg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/acorn": {
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
@@ -2989,15 +2984,6 @@
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.1.0"
-      }
-    },
-    "node_modules/ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/ansi-escapes": {
@@ -3504,46 +3490,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/browserslist-generator": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/browserslist-generator/-/browserslist-generator-2.1.0.tgz",
-      "integrity": "sha512-ZFz4mAOgqm0cbwKaZsfJbYDbTXGoPANlte7qRsRJOfjB9KmmISQrXJxAVrnXG8C8v/QHNzXyeJt0Cfcks6zZvQ==",
-      "dev": true,
-      "dependencies": {
-        "@mdn/browser-compat-data": "^5.3.7",
-        "@types/object-path": "^0.11.1",
-        "@types/semver": "^7.5.0",
-        "@types/ua-parser-js": "^0.7.36",
-        "browserslist": "^4.21.10",
-        "caniuse-lite": "^1.0.30001518",
-        "isbot": "^3.6.13",
-        "object-path": "^0.11.8",
-        "semver": "^7.5.4",
-        "ua-parser-js": "^1.0.35"
-      },
-      "engines": {
-        "node": ">=16.15.1",
-        "npm": ">=7.0.0",
-        "pnpm": ">=3.2.0",
-        "yarn": ">=1.13"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/wessberg/browserslist-generator?sponsor=1"
-      }
-    },
-    "node_modules/browserslist-generator/node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -3901,21 +3847,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/compatfactory": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/compatfactory/-/compatfactory-3.0.0.tgz",
-      "integrity": "sha512-WD5kF7koPwVoyKL8p0LlrmIZtilrD46sQStyzzxzTFinMKN2Dxk1hN+sddLSQU1mGIZvQfU8c+ONSghvvM40jg==",
-      "dev": true,
-      "dependencies": {
-        "helpertypes": "^0.0.19"
-      },
-      "engines": {
-        "node": ">=14.9.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=3.x || >= 4.x || >= 5.x"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "dev": true,
@@ -4011,24 +3942,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/crosspath": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/crosspath/-/crosspath-2.0.0.tgz",
-      "integrity": "sha512-ju88BYCQ2uvjO2bR+SsgLSTwTSctU+6Vp2ePbKPgSCZyy4MWZxYsT738DlKVRE5utUjobjPRm1MkTYKJxCmpTA==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "^17.0.36"
-      },
-      "engines": {
-        "node": ">=14.9.0"
-      }
-    },
-    "node_modules/crosspath/node_modules/@types/node": {
-      "version": "17.0.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
-      "dev": true
     },
     "node_modules/css-declaration-sorter": {
       "version": "6.3.1",
@@ -5323,15 +5236,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/helpertypes": {
-      "version": "0.0.19",
-      "resolved": "https://registry.npmjs.org/helpertypes/-/helpertypes-0.0.19.tgz",
-      "integrity": "sha512-J00e55zffgi3yVnUp0UdbMztNkr2PnizEkOe9URNohnrNhW5X0QpegkuLpOmFQInpi93Nb8MCjQRHAiCDF42NQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -6141,15 +6045,6 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true
-    },
-    "node_modules/isbot": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/isbot/-/isbot-3.8.0.tgz",
-      "integrity": "sha512-vne1mzQUTR+qsMLeCBL9+/tgnDXRyc2pygLGl/WsgA+EZKIiB5Ehu0CiVTHIIk30zhJ24uGz4M5Ppse37aR0Hg==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -7130,15 +7025,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/object-path": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.8.tgz",
-      "integrity": "sha512-YJjNZrlXJFM42wTBn6zgOJVar9KFJvzx6sTWDte8sWZF//cnjl0BxHNpfZx+ZffXX63A9q0b1zsFiBX4g4X5KA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.12.0"
       }
     },
     "node_modules/object.assign": {
@@ -8801,6 +8687,39 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/rollup-plugin-dts": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-6.1.1.tgz",
+      "integrity": "sha512-aSHRcJ6KG2IHIioYlvAOcEq6U99sVtqDDKVhnwt70rW6tsz3tv5OSjEiWcgzfsHdLyGXZ/3b/7b/+Za3Y6r1XA==",
+      "dev": true,
+      "license": "LGPL-3.0-only",
+      "dependencies": {
+        "magic-string": "^0.30.10"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Swatinem"
+      },
+      "optionalDependencies": {
+        "@babel/code-frame": "^7.24.2"
+      },
+      "peerDependencies": {
+        "rollup": "^3.29.4 || ^4",
+        "typescript": "^4.5 || ^5.0"
+      }
+    },
+    "node_modules/rollup-plugin-dts/node_modules/magic-string": {
+      "version": "0.30.14",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.14.tgz",
+      "integrity": "sha512-5c99P1WKTed11ZC0HMJOj6CDIue6F8ySu+bJL+85q1zBEIY8IklrJ1eiKC2NDRh3Ct3FcvmJPyQHb9erXMTJNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
     "node_modules/rollup-plugin-postcss": {
       "version": "4.0.2",
       "dev": true,
@@ -8889,77 +8808,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/rollup-plugin-ts": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-ts/-/rollup-plugin-ts-3.4.5.tgz",
-      "integrity": "sha512-9iCstRJpEZXSRQuXitlSZAzcGlrqTbJg1pE4CMbEi6xYldxVncdPyzA2I+j6vnh73wBymZckerS+Q/iEE/M3Ow==",
-      "dev": true,
-      "dependencies": {
-        "@rollup/pluginutils": "^5.0.2",
-        "@wessberg/stringutil": "^1.0.19",
-        "ansi-colors": "^4.1.3",
-        "browserslist": "^4.21.10",
-        "browserslist-generator": "^2.1.0",
-        "compatfactory": "^3.0.0",
-        "crosspath": "^2.0.0",
-        "magic-string": "^0.30.2",
-        "ts-clone-node": "^3.0.0",
-        "tslib": "^2.6.1"
-      },
-      "engines": {
-        "node": ">=16.15.1",
-        "npm": ">=7.0.0",
-        "pnpm": ">=3.2.0",
-        "yarn": ">=1.13"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/wessberg/rollup-plugin-ts?sponsor=1"
-      },
-      "peerDependencies": {
-        "@babel/core": ">=7.x",
-        "@babel/plugin-transform-runtime": ">=7.x",
-        "@babel/preset-env": ">=7.x",
-        "@babel/preset-typescript": ">=7.x",
-        "@babel/runtime": ">=7.x",
-        "@swc/core": ">=1.x",
-        "@swc/helpers": ">=0.2",
-        "rollup": ">=1.x || >=2.x || >=3.x",
-        "typescript": ">=3.2.x || >= 4.x || >= 5.x"
-      },
-      "peerDependenciesMeta": {
-        "@babel/core": {
-          "optional": true
-        },
-        "@babel/plugin-transform-runtime": {
-          "optional": true
-        },
-        "@babel/preset-env": {
-          "optional": true
-        },
-        "@babel/preset-typescript": {
-          "optional": true
-        },
-        "@babel/runtime": {
-          "optional": true
-        },
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/helpers": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/rollup-plugin-ts/node_modules/magic-string": {
-      "version": "0.30.10",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
-      "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.15"
       }
     },
     "node_modules/rollup-plugin-typescript2": {
@@ -9710,25 +9558,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/ts-clone-node": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ts-clone-node/-/ts-clone-node-3.0.0.tgz",
-      "integrity": "sha512-egavvyHbIoelkgh1IC2agNB1uMNjB8VJgh0g/cn0bg2XXTcrtjrGMzEk4OD3Fi2hocICjP3vMa56nkzIzq0FRg==",
-      "dev": true,
-      "dependencies": {
-        "compatfactory": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14.9.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/wessberg/ts-clone-node?sponsor=1"
-      },
-      "peerDependencies": {
-        "typescript": "^3.x || ^4.x || ^5.x"
-      }
-    },
     "node_modules/tslib": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
@@ -9824,29 +9653,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/ua-parser-js": {
-      "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.38.tgz",
-      "integrity": "sha512-Aq5ppTOfvrCMgAPneW1HfWj66Xi7XL+/mIy996R1/CLS/rcyJQm6QZdsKrUeivDFQ+Oc9Wyuwor8Ze8peEoUoQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        }
-      ],
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,15 @@
     "vitest": "2.1.5"
   },
   "files": [
-    "./dist/index.*"
+    "./dist/index.cjs",
+    "./dist/index.cjs.map",
+    "./dist/index.mjs",
+    "./dist/index.mjs.map",
+    "./dist/index.umd.js",
+    "./dist/index.umd.js.map",
+    "./dist/index.umd.d.ts",
+    "./dist/index.d.cts",
+    "./dist/index.d.mts"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -48,17 +48,18 @@
   "devDependencies": {
     "@rollup/plugin-node-resolve": "15.3.0",
     "@rollup/plugin-terser": "0.4.4",
+    "@rollup/plugin-typescript": "12.1.1",
     "@types/node": "22.9.0",
     "microbundle": "0.15.1",
     "prettier": "3.3.3",
     "release-it": "17.10.0",
     "rollup": "4.26.0",
-    "rollup-plugin-ts": "3.4.5",
+    "rollup-plugin-dts": "6.1.1",
     "typescript": "5.6.3",
     "vitest": "2.1.5"
   },
   "files": [
-    "./dist"
+    "./dist/index.*"
   ],
   "repository": {
     "type": "git",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,31 +1,60 @@
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import terser from '@rollup/plugin-terser';
-import ts from 'rollup-plugin-ts';
+import ts from '@rollup/plugin-typescript';
+import { dts } from 'rollup-plugin-dts';
+
+const runtimePlugins = () => [nodeResolve(), ts(), terser()];
+const dtsPlugins = () => [
+  nodeResolve(),
+  ts({ compilerOptions: { sourceMap: false } }),
+  dts(),
+];
 
 export default [
+  // Bundle runtime
   {
     input: 'src/index.ts',
     output: {
+      sourcemap: true,
       file: 'dist/index.cjs',
       format: 'cjs',
     },
-    plugins: [nodeResolve(), ts({ tsconfig: 'tsconfig.json' }), terser()],
+    plugins: runtimePlugins(),
   },
   {
     input: 'src/index.ts',
     output: {
+      sourcemap: true,
       file: 'dist/index.mjs',
       format: 'esm',
     },
-    plugins: [nodeResolve(), ts({ tsconfig: 'tsconfig.json' }), terser()],
+    plugins: runtimePlugins(),
   },
   {
     input: 'src/index.ts',
     output: {
+      sourcemap: true,
       file: 'dist/index.umd.js',
       format: 'umd',
       name: 'graphDataStructure',
     },
-    plugins: [nodeResolve(), ts({ tsconfig: 'tsconfig.json' }), terser()],
+    plugins: runtimePlugins(),
+  },
+
+  // Bundle types definitions
+  {
+    input: './dist/index.d.ts',
+    output: [{ file: 'dist/index.d.cts', format: 'cjs' }],
+    plugins: dtsPlugins(),
+  },
+  {
+    input: './dist/index.d.ts',
+    output: [{ file: 'dist/index.d.mts', format: 'esm' }],
+    plugins: dtsPlugins(),
+  },
+  {
+    input: './dist/index.d.ts',
+    output: [{ file: 'dist/index.umd.d.ts', format: 'umd' }],
+    plugins: dtsPlugins(),
   },
 ];


### PR DESCRIPTION
Closes #97 

Node v22 gets rid of the `assert` keyword, which is used by one of the rollup plugins we used.

Rollup had major internal and plugin updates. Those updated versions no longer use this keyword.
This PR updates the rollup plugins we use and the config file accordingly.

On a side note : after building, the output directory now contains the bundled and unbundled type definitions. 
To avoid packaging them both (only the bundled ones are required), I've also updated the `files` property of the `package.json`.